### PR TITLE
Make the data conform to RandomAccessCollection

### DIFF
--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -165,3 +165,18 @@ struct TestWithDeletion_Previews: PreviewProvider {
     TestWithDeletion()
   }
 }
+
+struct TestWithRange_Previews: PreviewProvider {
+    static var previews: some View {
+        FlowLayout(mode: .scrollable,
+                   items: 1..<100) {
+            Text("\($0)")
+                .font(.system(size: 12))
+                .foregroundColor(.black)
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 4)
+                    .border(Color.gray)
+                    .foregroundColor(Color.gray))
+        }.padding()
+    }
+}

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -2,20 +2,20 @@ import SwiftUI
 
 public let flowLayoutDefaultItemSpacing: CGFloat = 4
 
-public struct FlowLayout<RefreshBinding, Data, ItemView: View>: View {
+public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, ItemView: View>: View where Data.Element: Hashable {
   let mode: Mode
   @Binding var binding: RefreshBinding
-  let items: [Data]
+  let items: Data
   let itemSpacing: CGFloat
-  @ViewBuilder let viewMapping: (Data) -> ItemView
+  @ViewBuilder let viewMapping: (Data.Element) -> ItemView
 
   @State private var totalHeight: CGFloat
 
   public init(mode: Mode,
               binding: Binding<RefreshBinding>,
-              items: [Data],
+              items: Data,
               itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
-              @ViewBuilder viewMapping: @escaping (Data) -> ItemView) {
+              @ViewBuilder viewMapping: @escaping (Data.Element) -> ItemView) {
     self.mode = mode
     _binding = binding
     self.items = items
@@ -100,9 +100,9 @@ private struct HeightReaderView: View {
 
 public extension FlowLayout where RefreshBinding == Never? {
     init(mode: Mode,
-         items: [Data],
+         items: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
-         @ViewBuilder viewMapping: @escaping (Data) -> ItemView) {
+         @ViewBuilder viewMapping: @escaping (Data.Element) -> ItemView) {
         self.init(mode: mode,
                   binding: .constant(nil),
                   items: items,


### PR DESCRIPTION
It now supports the entire range of hashable collections, including arrays, ranges, sets, and more