### PR TITLE
Refactor: Improve naming

### DIFF
--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -180,3 +180,39 @@ struct TestWithRange_Previews: PreviewProvider {
         }.padding()
     }
 }
+
+// MARK: Migration Helpers
+
+public extension FlowLayout {
+    @available(swift, obsoleted: 1.1.0, renamed: "attemptConnection")
+    var viewMapping: (Data.Element) -> Content { content }
+
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:binding:items:itemSpacing:content:)")
+    init(mode: Mode,
+         binding: Binding<RefreshBinding>,
+         items: Data,
+         itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
+         @ViewBuilder viewMapping: @escaping (Data.Element) -> Content) {
+        self.init(mode: mode,
+                  binding: binding,
+                  items: items,
+                  itemSpacing: itemSpacing,
+                  content: viewMapping)
+    }
+}
+
+public extension FlowLayout where RefreshBinding == Never? {
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:items:itemSpacing:content:)")
+    init(mode: Mode,
+         items: Data,
+         itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
+         @ViewBuilder viewMapping: @escaping (Data.Element) -> Content) {
+        self.init(
+            mode: mode,
+            binding: .constant(nil),
+            items: items,
+            itemSpacing: itemSpacing,
+            content: viewMapping
+        )
+    }
+}

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 public let flowLayoutDefaultItemSpacing: CGFloat = 4
 
-public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
+public struct FlowLayout<Trigger, Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
   let mode: Mode
-  @Binding var binding: RefreshBinding
+  @Binding var trigger: Trigger
   let data: Data
   let itemSpacing: CGFloat
   @ViewBuilder let content: (Data.Element) -> Content
@@ -12,12 +12,12 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: 
   @State private var totalHeight: CGFloat
 
   public init(mode: Mode,
-              binding: Binding<RefreshBinding>,
+              trigger: Binding<Trigger>,
               data: Data,
               itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
               @ViewBuilder content: @escaping (Data.Element) -> Content) {
     self.mode = mode
-    _binding = binding
+    _trigger = trigger
     self.data = data
     self.itemSpacing = itemSpacing
     self.content = content
@@ -71,7 +71,7 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: 
               })
         }
       }
-      .background(HeightReaderView(binding: $totalHeight))
+      .background(HeightReaderView(trigger: $totalHeight))
   }
 
   public enum Mode {
@@ -85,26 +85,26 @@ private struct HeightPreferenceKey: PreferenceKey {
 }
 
 private struct HeightReaderView: View {
-  @Binding var binding: CGFloat
+  @Binding var trigger: CGFloat
   var body: some View {
     GeometryReader { geo in
       Color.clear
            .preference(key: HeightPreferenceKey.self, value: geo.frame(in: .local).size.height)
     }
     .onPreferenceChange(HeightPreferenceKey.self) { h in
-      binding = h
+      trigger = h
     }
   }
 }
 
 
-public extension FlowLayout where RefreshBinding == Never? {
+public extension FlowLayout where Trigger == Never? {
     init(mode: Mode,
          data: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
          @ViewBuilder content: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
-                  binding: .constant(nil),
+                  trigger: .constant(nil),
                   data: data,
                   itemSpacing: itemSpacing,
                   content: content)
@@ -188,21 +188,21 @@ public extension FlowLayout {
     @available(swift, obsoleted: 1.1.0, renamed: "attemptConnection")
     var viewMapping: (Data.Element) -> Content { content }
 
-    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:binding:data:itemSpacing:content:)")
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:trigger:data:itemSpacing:content:)")
     init(mode: Mode,
-         binding: Binding<RefreshBinding>,
+         binding: Binding<Trigger>,
          items: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
          @ViewBuilder viewMapping: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
-                  binding: binding,
+                  trigger: binding,
                   data: items,
                   itemSpacing: itemSpacing,
                   content: viewMapping)
     }
 }
 
-public extension FlowLayout where RefreshBinding == Never? {
+public extension FlowLayout where Trigger == Never? {
     @available(swift, obsoleted: 1.1.0, renamed: "init(mode:data:itemSpacing:content:)")
     init(mode: Mode,
          items: Data,
@@ -210,7 +210,7 @@ public extension FlowLayout where RefreshBinding == Never? {
          @ViewBuilder viewMapping: @escaping (Data.Element) -> Content) {
         self.init(
             mode: mode,
-            binding: .constant(nil),
+            trigger: .constant(nil),
             data: items,
             itemSpacing: itemSpacing,
             content: viewMapping

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 public let flowLayoutDefaultItemSpacing: CGFloat = 4
 
-public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, ItemView: View>: View where Data.Element: Hashable {
+public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
   let mode: Mode
   @Binding var binding: RefreshBinding
   let items: Data
   let itemSpacing: CGFloat
-  @ViewBuilder let viewMapping: (Data.Element) -> ItemView
+  @ViewBuilder let content: (Data.Element) -> Content
 
   @State private var totalHeight: CGFloat
 
@@ -15,12 +15,12 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, ItemView:
               binding: Binding<RefreshBinding>,
               items: Data,
               itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
-              @ViewBuilder viewMapping: @escaping (Data.Element) -> ItemView) {
+              @ViewBuilder content: @escaping (Data.Element) -> Content) {
     self.mode = mode
     _binding = binding
     self.items = items
     self.itemSpacing = itemSpacing
-    self.viewMapping = viewMapping
+    self.content = content
     _totalHeight = State(initialValue: (mode == .scrollable) ? .zero : .infinity)
   }
 
@@ -46,7 +46,7 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, ItemView:
     let itemCount = items.count
     return ZStack(alignment: .topLeading) {
         ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-            viewMapping(item)
+            content(item)
               .padding([.horizontal, .vertical], itemSpacing)
               .alignmentGuide(.leading, computeValue: { d in
                 if (abs(width - d.width) > g.size.width) {
@@ -102,12 +102,12 @@ public extension FlowLayout where RefreshBinding == Never? {
     init(mode: Mode,
          items: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
-         @ViewBuilder viewMapping: @escaping (Data.Element) -> ItemView) {
+         @ViewBuilder content: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
                   binding: .constant(nil),
                   items: items,
                   itemSpacing: itemSpacing,
-                  viewMapping: viewMapping)
+                  content: content)
     }
 }
 

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -6,7 +6,7 @@ public struct FlowLayout<Trigger, Data, Content>: View where Data: RandomAccessC
   let mode: Mode
   @Binding var trigger: Trigger
   let data: Data
-  let itemSpacing: CGFloat
+  let spacing: CGFloat
   @ViewBuilder let content: (Data.Element) -> Content
 
   @State private var totalHeight: CGFloat
@@ -14,12 +14,12 @@ public struct FlowLayout<Trigger, Data, Content>: View where Data: RandomAccessC
   public init(mode: Mode,
               trigger: Binding<Trigger>,
               data: Data,
-              itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
+              spacing: CGFloat = flowLayoutDefaultItemSpacing,
               @ViewBuilder content: @escaping (Data.Element) -> Content) {
     self.mode = mode
     _trigger = trigger
     self.data = data
-    self.itemSpacing = itemSpacing
+    self.spacing = spacing
     self.content = content
     _totalHeight = State(initialValue: (mode == .scrollable) ? .zero : .infinity)
   }
@@ -47,7 +47,7 @@ public struct FlowLayout<Trigger, Data, Content>: View where Data: RandomAccessC
     return ZStack(alignment: .topLeading) {
         ForEach(Array(data.enumerated()), id: \.offset) { index, item in
             content(item)
-              .padding([.horizontal, .vertical], itemSpacing)
+              .padding([.horizontal, .vertical], spacing)
               .alignmentGuide(.leading, computeValue: { d in
                 if (abs(width - d.width) > g.size.width) {
                   width = 0
@@ -101,12 +101,12 @@ private struct HeightReaderView: View {
 public extension FlowLayout where Trigger == Never? {
     init(mode: Mode,
          data: Data,
-         itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
+         spacing: CGFloat = flowLayoutDefaultItemSpacing,
          @ViewBuilder content: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
                   trigger: .constant(nil),
                   data: data,
-                  itemSpacing: itemSpacing,
+                  spacing: spacing,
                   content: content)
     }
 }
@@ -188,7 +188,7 @@ public extension FlowLayout {
     @available(swift, obsoleted: 1.1.0, renamed: "attemptConnection")
     var viewMapping: (Data.Element) -> Content { content }
 
-    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:trigger:data:itemSpacing:content:)")
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:trigger:data:spacing:content:)")
     init(mode: Mode,
          binding: Binding<Trigger>,
          items: Data,
@@ -197,13 +197,13 @@ public extension FlowLayout {
         self.init(mode: mode,
                   trigger: binding,
                   data: items,
-                  itemSpacing: itemSpacing,
+                  spacing: itemSpacing,
                   content: viewMapping)
     }
 }
 
 public extension FlowLayout where Trigger == Never? {
-    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:data:itemSpacing:content:)")
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:data:spacing:content:)")
     init(mode: Mode,
          items: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
@@ -212,7 +212,7 @@ public extension FlowLayout where Trigger == Never? {
             mode: mode,
             trigger: .constant(nil),
             data: items,
-            itemSpacing: itemSpacing,
+            spacing: itemSpacing,
             content: viewMapping
         )
     }

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -5,7 +5,7 @@ public let flowLayoutDefaultItemSpacing: CGFloat = 4
 public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
   let mode: Mode
   @Binding var binding: RefreshBinding
-  let items: Data
+  let data: Data
   let itemSpacing: CGFloat
   @ViewBuilder let content: (Data.Element) -> Content
 
@@ -13,12 +13,12 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: 
 
   public init(mode: Mode,
               binding: Binding<RefreshBinding>,
-              items: Data,
+              data: Data,
               itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
               @ViewBuilder content: @escaping (Data.Element) -> Content) {
     self.mode = mode
     _binding = binding
-    self.items = items
+    self.data = data
     self.itemSpacing = itemSpacing
     self.content = content
     _totalHeight = State(initialValue: (mode == .scrollable) ? .zero : .infinity)
@@ -43,9 +43,9 @@ public struct FlowLayout<RefreshBinding, Data: RandomAccessCollection, Content: 
     var width = CGFloat.zero
     var height = CGFloat.zero
     var lastHeight = CGFloat.zero
-    let itemCount = items.count
+    let itemCount = data.count
     return ZStack(alignment: .topLeading) {
-        ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+        ForEach(Array(data.enumerated()), id: \.offset) { index, item in
             content(item)
               .padding([.horizontal, .vertical], itemSpacing)
               .alignmentGuide(.leading, computeValue: { d in
@@ -100,12 +100,12 @@ private struct HeightReaderView: View {
 
 public extension FlowLayout where RefreshBinding == Never? {
     init(mode: Mode,
-         items: Data,
+         data: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
          @ViewBuilder content: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
                   binding: .constant(nil),
-                  items: items,
+                  data: data,
                   itemSpacing: itemSpacing,
                   content: content)
     }
@@ -114,7 +114,7 @@ public extension FlowLayout where RefreshBinding == Never? {
 struct FlowLayout_Previews: PreviewProvider {
   static var previews: some View {
     FlowLayout(mode: .scrollable,
-               items: ["Some long item here", "And then some longer one",
+               data: ["Some long item here", "And then some longer one",
                       "Short", "Items", "Here", "And", "A", "Few", "More",
                       "And then a very very very long long long long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long long long one", "and", "then", "some", "short short short ones"]) {
       Text($0)
@@ -129,25 +129,26 @@ struct FlowLayout_Previews: PreviewProvider {
 }
 
 struct TestWithDeletion: View {
-    @State private var items = ["Some long item here", "And then some longer one",
+    @State private var data = ["Some long item here", "And then some longer one",
                                 "Short", "Items", "Here", "And", "A", "Few", "More",
                                 "And then a very very very long long long long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long long long one", "and", "then", "some", "short short short ones"]
     
     var body: some View {
         VStack {
         Button("Delete all") {
-            items.removeAll()
+            data.removeAll()
         }
             Button("Restore") {
-                items = ["Some long item here", "And then some longer one",
+                data = ["Some long item here", "And then some longer one",
                          "Short", "Items", "Here", "And", "A", "Few", "More",
                          "And then a very very very long long long long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long longlong long long long long long long long one", "and", "then", "some", "short short short ones"]
             }
             Button("Add one") {
-                items.append("\(Date().timeIntervalSince1970)")
+                data.append("\(Date().timeIntervalSince1970)")
             }
         FlowLayout(mode: .vstack,
-                   items: items) {
+                   data: data) {
+
           Text($0)
             .font(.system(size: 12))
             .foregroundColor(.black)
@@ -169,7 +170,7 @@ struct TestWithDeletion_Previews: PreviewProvider {
 struct TestWithRange_Previews: PreviewProvider {
     static var previews: some View {
         FlowLayout(mode: .scrollable,
-                   items: 1..<100) {
+                   data: 1..<100) {
             Text("\($0)")
                 .font(.system(size: 12))
                 .foregroundColor(.black)
@@ -187,7 +188,7 @@ public extension FlowLayout {
     @available(swift, obsoleted: 1.1.0, renamed: "attemptConnection")
     var viewMapping: (Data.Element) -> Content { content }
 
-    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:binding:items:itemSpacing:content:)")
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:binding:data:itemSpacing:content:)")
     init(mode: Mode,
          binding: Binding<RefreshBinding>,
          items: Data,
@@ -195,14 +196,14 @@ public extension FlowLayout {
          @ViewBuilder viewMapping: @escaping (Data.Element) -> Content) {
         self.init(mode: mode,
                   binding: binding,
-                  items: items,
+                  data: items,
                   itemSpacing: itemSpacing,
                   content: viewMapping)
     }
 }
 
 public extension FlowLayout where RefreshBinding == Never? {
-    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:items:itemSpacing:content:)")
+    @available(swift, obsoleted: 1.1.0, renamed: "init(mode:data:itemSpacing:content:)")
     init(mode: Mode,
          items: Data,
          itemSpacing: CGFloat = flowLayoutDefaultItemSpacing,
@@ -210,7 +211,7 @@ public extension FlowLayout where RefreshBinding == Never? {
         self.init(
             mode: mode,
             binding: .constant(nil),
-            items: items,
+            data: items,
             itemSpacing: itemSpacing,
             content: viewMapping
         )

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public let flowLayoutDefaultItemSpacing: CGFloat = 4
 
-public struct FlowLayout<Trigger, Data: RandomAccessCollection, Content: View>: View where Data.Element: Hashable {
+public struct FlowLayout<Trigger, Data, Content>: View where Data: RandomAccessCollection, Data.Element: Hashable, Content: View {
   let mode: Mode
   @Binding var trigger: Trigger
   let data: Data


### PR DESCRIPTION
I used the naming based on the original SwiftUI component namings. This will reduce the learning curve and enhance the developer experience

Based on the original `Grid`, `VStack`, `ForEach`, etc.

Note that the old users can automatically migrate to this newer API with a simple tap on the `Fix` button.

![Screenshot 2024-09-05 at 2 33 55 PM](https://github.com/user-attachments/assets/83ba4e16-390e-455e-985e-d010ef792f4a)
