### PR TITLE
draft: Precise spacing

### DIFF
--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -40,7 +40,6 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
   }
 
   private func content(in g: GeometryProxy) -> some View {
-    var height = CGFloat.zero
     var width = CGFloat.zero {
       didSet {
         if width == 0 {
@@ -51,12 +50,21 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
       }
     }
     var row = 0
+    var height = CGFloat.zero{
+      didSet {
+        if height == 0 {
+          column = 0
+        } else {
+          column += 1
+        }
+      }
+    }
+    var column = 0
     var lastHeight = CGFloat.zero
     let itemCount = items.count
     return ZStack(alignment: .topLeading) {
         ForEach(Array(items.enumerated()), id: \.offset) { index, item in
             viewMapping(item)
-              .padding([.vertical], itemSpacing)
               .alignmentGuide(.leading, computeValue: { d in
                 if (abs(width - d.width) > g.size.width) {
                   width = 0
@@ -74,10 +82,11 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
               })
               .alignmentGuide(.top, computeValue: { d in
                 let result = height
+                let extraHeight = -itemSpacing * CGFloat(column)
                 if index == itemCount - 1 {
                   height = 0
                 }
-                return result
+                return result + extraHeight
               })
         }
       }

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -43,16 +43,6 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
     var width = CGFloat.zero {
       didSet {
         if width == 0 {
-          row = 0
-        } else {
-          row += 1
-        }
-      }
-    }
-    var row = 0
-    var height = CGFloat.zero{
-      didSet {
-        if height == 0 {
           column = 0
         } else {
           column += 1
@@ -60,6 +50,16 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
       }
     }
     var column = 0
+    var height = CGFloat.zero{
+      didSet {
+        if height == 0 {
+          row = 0
+        } else {
+          row += 1
+        }
+      }
+    }
+    var row = 0
     var lastHeight = CGFloat.zero
     let itemCount = items.count
     return ZStack(alignment: .topLeading) {
@@ -72,7 +72,7 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
                 }
                 lastHeight = d.height
                 let currentWidth = width
-                let extraWidth = -itemSpacing * CGFloat(row)
+                let extraWidth = -itemSpacing * CGFloat(column)
                 if index == itemCount - 1 {
                   width = 0
                 } else {
@@ -82,7 +82,7 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
               })
               .alignmentGuide(.top, computeValue: { d in
                 let currentHeight = height
-                let extraHeight = -itemSpacing * CGFloat(column)
+                let extraHeight = -itemSpacing * CGFloat(row)
                 if index == itemCount - 1 {
                   height = 0
                 }

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -40,14 +40,23 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
   }
 
   private func content(in g: GeometryProxy) -> some View {
-    var width = CGFloat.zero
     var height = CGFloat.zero
+    var width = CGFloat.zero {
+      didSet {
+        if width == 0 {
+          row = 0
+        } else {
+          row += 1
+        }
+      }
+    }
+    var row = 0
     var lastHeight = CGFloat.zero
     let itemCount = items.count
     return ZStack(alignment: .topLeading) {
         ForEach(Array(items.enumerated()), id: \.offset) { index, item in
             viewMapping(item)
-              .padding([.horizontal, .vertical], itemSpacing)
+              .padding([.vertical], itemSpacing)
               .alignmentGuide(.leading, computeValue: { d in
                 if (abs(width - d.width) > g.size.width) {
                   width = 0
@@ -55,12 +64,13 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
                 }
                 lastHeight = d.height
                 let result = width
+                let extraWidth = -itemSpacing * CGFloat(row)
                 if index == itemCount - 1 {
                   width = 0
                 } else {
                   width -= d.width
                 }
-                return result
+                return result + extraWidth
               })
               .alignmentGuide(.top, computeValue: { d in
                 let result = height

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -71,22 +71,22 @@ public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View
                   height -= lastHeight
                 }
                 lastHeight = d.height
-                let result = width
+                let currentWidth = width
                 let extraWidth = -itemSpacing * CGFloat(row)
                 if index == itemCount - 1 {
                   width = 0
                 } else {
                   width -= d.width
                 }
-                return result + extraWidth
+                return currentWidth + extraWidth
               })
               .alignmentGuide(.top, computeValue: { d in
-                let result = height
+                let currentHeight = height
                 let extraHeight = -itemSpacing * CGFloat(column)
                 if index == itemCount - 1 {
                   height = 0
                 }
-                return result + extraHeight
+                return currentHeight + extraHeight
               })
         }
       }

--- a/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
+++ b/Sources/SwiftUIFlowLayout/SwiftUIFlowLayout.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public let flowLayoutDefaultItemSpacing: CGFloat = 4
+public let flowLayoutDefaultItemSpacing: CGFloat = 8
 
 public struct FlowLayout<RefreshBinding, Data: Collection, ItemView: View>: View {
   let mode: Mode


### PR DESCRIPTION
The original code used padding to simulate spacing, which caused 3 main issues:
1. Unintended padding around the collection.
2. Spacing being twice the intended length. (e.g. passing 4 but seeing 8)
3. The last Item sometimes does not fit into the layout although it there is enough available space.
You can notice all of these issues in the following example image

### Before this PR (With spacing of `4`)
<img width="363" alt="Screenshot 2024-09-05 at 3 04 27 PM" src="https://github.com/user-attachments/assets/0f033edc-617c-4698-8827-bffa9f4dc603">

--- 
### After this PR (With spacing of `8`)
This PR addresses the problem by applying the correct spacing, ensuring that the spacing is separate from the padding:
<img width="345" alt="Screenshot 2024-09-05 at 3 00 40 PM" src="https://github.com/user-attachments/assets/cb89ccfc-ad2f-47e3-bce4-ab3816bcdf01">

Additionally, I updated the default spacing from `4` to `8` to better align with the original design intent.